### PR TITLE
Invert `any_button_pressed` logic for pull-up

### DIFF
--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -202,7 +202,7 @@ class Peripherals:
         """
         Return whether any button is pressed
         """
-        return True in [button.value for (i, button) in enumerate(self._buttons)]
+        return True in [not button.value for (i, button) in enumerate(self._buttons)]
 
     @property
     def dac(self):


### PR DESCRIPTION
There's a small logic error in the `adafruit_fruitjam.peripherals.Peripherals.any_button_pressed` property caused by the GPIO input pull-up. This update fixes that error so that it matches the output of `self.button1 or self.button2 or self.button3`.