### PR TITLE
Automatically configure display size based on `CIRCUITPY_DISPLAY_WIDTH`

### DIFF
--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -63,8 +63,11 @@ def request_display_config(width=None, height=None, color_depth=None):
 
     This function will set the initialized display to ``supervisor.runtime.display``
 
-    :param width: The width of the display in pixels.
-    :param height: The height of the display in pixels.
+    :param width: The width of the display in pixels. Leave unspecified to default
+      to the ``CIRCUITPY_DISPLAY_WIDTH`` environmental variable if provided. Otherwise,
+      a ``ValueError`` exception will be thrown.
+    :param height: The height of the display in pixels. Leave unspecified to default
+      to the appropriate height for the provided width.
     :param color_depth: The color depth of the display in bits.
       Valid values are 1, 2, 4, 8, 16, 32. Larger resolutions must use
       smaller color_depths due to RAM limitations. Default color_depth for


### PR DESCRIPTION
This update allows `request_display_config` to automatically configure the display to the user's preference (as determined by `CIRCUITPY_DISPLAY_WIDTH`) if a specific size is not provided. It also allows the user to provide a desired width and automatically determine the appropriate display height.

These changes are based on the implementation in Fruit-Jam-OS (https://github.com/adafruit/Fruit-Jam-OS/pull/44) and hopefully could add uniformity to applications based in that ecosystem which support multiple display sizes rather than implementing this functionality independently.