### PR TITLE
allow passed in pins for TLV320, volume limit too low

### DIFF
--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -143,9 +143,16 @@ class Peripherals:
             See https://circuitpython.readthedocs.io/projects/neopixel/en/latest/api.html
     """
 
-    def __init__(self, audio_output="headphone", safe_volume_limit=17,
-        tlv_i2c=None, bclk=None, ws=None, din=None):
-
+    def __init__(  # noqa: PLR0913 Too many arguments in function definition
+        self,
+        audio_output="headphone",
+        safe_volume_limit=17,
+        *,
+        tlv_i2c=None,
+        bclk=None,
+        ws=None,
+        din=None,
+    ):
         self.neopixels = NeoPixel(board.NEOPIXEL, 5)
 
         self._buttons = []
@@ -163,7 +170,7 @@ class Peripherals:
 
         # set sample rate & bit depth
         self._dac.configure_clocks(sample_rate=11030, bit_depth=16)
-            
+
         self._audio_output = audio_output
         self.audio_output = audio_output
 

--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -137,6 +137,10 @@ class Peripherals:
     :param audio_output: The audio output interface to use 'speaker' or 'headphone'
     :param safe_volume_limit: The maximum volume allowed for the audio output. Default is 15
         Using higher values can damage some speakers, change at your own risk.
+    :param dac=None: DAC object to be used instead of the default FruitJam TLV320 object
+        If a DAC object is passed in the clocks must be configured by the calling program
+    :param i2s_audio=None: I2SOut object to be used instead of the default object built
+        using the default FruitJam I2S pins.
 
     Attributes:
         neopixels (NeoPxiels): The NeoPixels on the Fruit Jam board.

--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -170,7 +170,7 @@ class Peripherals:
 
         # I know we're only really concerned about TLV320 DACs but this seems like an
         # easy check to give the option of passing in objects from other DACs
-        if hasattr(self._dac, "headphone_volume") and hasattr(self._dac, "speaker_volume"):
+        if hasattr(self._dac, "headphone_output") and hasattr(self._dac, "speaker_output"):
             self._audio_output = audio_output
             self.audio_output = audio_output
 


### PR DESCRIPTION
I was working on refactoring the new audio API into some of the Fruit Jam apps and realized that for apps that might be run on other boards like the Metro RP2350 with a TLV320 breakout, the library would crash when trying to use the defined I2S pins that the Fruit Jam has. I think we may have the same issue if we try and use the library's screen API but I didn't look closely at that. (maybe the Metro RP2350 has the same DVI pin names so at least that board would work)

This is the Fruit Jam library so I understand if we don't care that it doesn't work on other boards in which case I'll just stick to using the TLV320 library for Apps that may run on other boards.

I also found that the new volume settings were too soft. I set the default safe_volume_limit up to 17. The old value translated to -11.4dB and the 17 translates to about 10 which I found was still not loud on both headphones and the speaker. I'm going to also open an issue about the volume level so if you would like me to drop that change from this PR for now I can do that too.