### PR TITLE
Add peripherals deinitialization

### DIFF
--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -383,3 +383,29 @@ for the safe_volume_limit with the constructor or property."""
         if self._dac is not None:
             db_val = map_range(self._volume, 1, 20, -63, 23)
             self._dac.dac_volume = db_val
+
+    def deinit(self) -> None:
+        """
+        Deinitializes Peripherals and releases any hardware resources for reuse.
+        """
+        if self.neopixels is not None:
+            self.neopixels.deinit()
+            self.neopixels = None
+
+        if self._buttons is not None:
+            for button in self._buttons:
+                button.deinit()
+            self._buttons = None
+
+        if self._audio is not None:
+            self._audio.stop()
+            self._audio.deinit()
+            self._audio = None
+
+        if self._dac is not None:
+            self._dac.reset()
+            self._dac = None
+
+        if self._mp3_decoder is not None:
+            self._mp3_decoder.deinit()
+            self._mp3_decoder = None


### PR DESCRIPTION
This update adds a method, `adafruit_fruitjam.peripherals.Peripherals.deinit` which handles deinitialization and releases hardware resources.

_Note: One quick CircuitPython n00b question, is it better to `del self.neopixels` or `self.neopixels = None` or both? (`del` then set to `None`)_