### PR TITLE
Initialize `wavfile` in `adafruit_fruitjam.peripherals.Peripherals` constructor

### DIFF
--- a/adafruit_fruitjam/peripherals.py
+++ b/adafruit_fruitjam/peripherals.py
@@ -224,7 +224,9 @@ class Peripherals:
             except OSError:
                 # sdcard init or mounting failed
                 self._sd_mounted = False
+
         self._mp3_decoder = None
+        self.wavfile = None
 
     @property
     def button1(self) -> bool:


### PR DESCRIPTION
If you attempt to call `stop_play()` before calling `play_file`, the `wavfile` property will not be defined and throw an `AttributeError`. This fix simply declares this property as `None` within the constructor to prevent this error.

### Board Definition

``` python
Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Fruit Jam with rp2350b
```

### Example Code

``` python
import adafruit_fruitjam.peripherals
peripherals = adafruit_fruitjam.peripherals.Peripherals()
peripherals.stop_play()
```

### REPL Output

_(before fix)_

``` python
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "adafruit_fruitjam/peripherals.py", line 336, in stop_play
AttributeError: 'Peripherals' object has no attribute 'wavfile'
```